### PR TITLE
Handle longer test names

### DIFF
--- a/lib/template.html.erb
+++ b/lib/template.html.erb
@@ -76,6 +76,10 @@
         opacity: 0.5;
         margin-bottom: 20px;
       }
+
+      #results {
+        max-width: 65%;
+      }
     </style>
   </head>
   <body>

--- a/rspec-nice-html-formatter.gemspec
+++ b/rspec-nice-html-formatter.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "rspec-nice-html-formatter"
-  spec.version       = "1.0"
+  spec.version       = "1.0.1"
   spec.authors       = ["ecin"]
   spec.email         = ["ecin@copypastel.com"]
   spec.description   = "A nice HTML formatter for your RSpec tests 🌈"

--- a/spec/nice_html_formatter_spec.rb
+++ b/spec/nice_html_formatter_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe NiceHTMLFormatter do
     raise RuntimeError
   end
 
+  it "looks nice even if it fails for a test with a really long description like this one, I mean, like a really reall long description, so long that I wonder just how many different context blocks the test went through before arriving at its final, clear assertion" do
+    fail
+  end
+
   it "is pending"
 
   xit "is disabled" do


### PR DESCRIPTION
Now text wraps around if it exceeds a certain length.

<img width="901" alt="better" src="https://user-images.githubusercontent.com/646/34457787-c8de0ac0-ed70-11e7-91dd-48d901c4b612.png">
